### PR TITLE
fix max33() when numbr > len(seqs)

### DIFF
--- a/insitu_probe_generator/maker37cb.py
+++ b/insitu_probe_generator/maker37cb.py
@@ -131,9 +131,9 @@ def maker(name,fullseq,amplifier,pause,choose,polyAT,polyCG,BlastProbes,db,dropo
                         a+=1
                         pass     
                 return(reduced)
-        elif  int(numbr) >=  int(len(seqs)):
-            print("There was were fewer than "+str(numbr)+" pairs, no action taken.")
-            return(seqs)
+            elif int(numbr) >=  int(len(seqs)):
+                print("There was were fewer than "+str(numbr)+" pairs, no action taken.")
+                return(seqs)
         else:
             return(seqs)
 


### PR DESCRIPTION
wrong indentation in max33. If the user asked for more sequences than what is possible, the function would never reach the `elif` and return "None" by default.